### PR TITLE
Update for compatibility with Ghost version 1.21.7

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,41 +1,41 @@
 {
-	"name": "Slimpost",
-	"version": "0.3.0",
-	"dependencies": {
-		"normalize-css": "latest",
-		"font-awesome": "latest",
-		"fitvids": "latest",
-		"nprogress": "latest"
-	},
-	"install": {
-	    "path": {
-	    	"css": "src/scss/vendor/bower",
-	      	"js": "src/js/vendor/bower",
-	      	"eot": "assets/fonts",
-	        "svg": "assets/fonts",
-	        "ttf": "assets/fonts",
-	        "woff": "assets/fonts",
-	        "otf": "assets/fonts"
-	    },
-	    "sources": {
-	    	"fitvids": "src/bower_components/fitvids/jquery.fitvids.js",
-	      	"normalize-css": {
-	      		"mapping": [
-	      			{ "src/bower_components/normalize-css/normalize.css": "_normalize.scss" }
-	      		]
-	      	},
-	      	"font-awesome": {
-	      		"mapping": [
-	      			{ "src/bower_components/font-awesome/css/font-awesome.css": "_font-awesome.scss" },
-	      			{ "src/bower_components/font-awesome/fonts/fontawesome-webfont.eot": "fontawesome-webfont.eot" },
-	      			{ "src/bower_components/font-awesome/fonts/fontawesome-webfont.svg": "fontawesome-webfont.svg" },
-	      			{ "src/bower_components/font-awesome/fonts/fontawesome-webfont.ttf": "fontawesome-webfont.ttf" },
-	      			{ "src/bower_components/font-awesome/fonts/fontawesome-webfont.woff": "fontawesome-webfont.woff" },
-	      			{ "src/bower_components/font-awesome/fonts/FontAwesome.otf": "FontAwesome.otf" }
-	      		]
-	      	},
-	      	"nprogress": "src/bower_components/nprogress/nprogress.js"
-	    },
-	    "ignore": ["jquery"]
-  	}
+  "name": "Slimpost",
+  "version": "0.3.0",
+  "dependencies": {
+    "normalize-css": "latest",
+    "font-awesome": "latest",
+    "fitvids": "latest",
+    "nprogress": "latest"
+  },
+  "install": {
+      "path": {
+        "css": "src/scss/vendor/bower",
+          "js": "src/js/vendor/bower",
+          "eot": "assets/fonts",
+          "svg": "assets/fonts",
+          "ttf": "assets/fonts",
+          "woff": "assets/fonts",
+          "otf": "assets/fonts"
+      },
+      "sources": {
+        "fitvids": "src/bower_components/fitvids/jquery.fitvids.js",
+          "normalize-css": {
+            "mapping": [
+              { "src/bower_components/normalize-css/normalize.css": "_normalize.scss" }
+            ]
+          },
+          "font-awesome": {
+            "mapping": [
+              { "src/bower_components/font-awesome/css/font-awesome.css": "_font-awesome.scss" },
+              { "src/bower_components/font-awesome/fonts/fontawesome-webfont.eot": "fontawesome-webfont.eot" },
+              { "src/bower_components/font-awesome/fonts/fontawesome-webfont.svg": "fontawesome-webfont.svg" },
+              { "src/bower_components/font-awesome/fonts/fontawesome-webfont.ttf": "fontawesome-webfont.ttf" },
+              { "src/bower_components/font-awesome/fonts/fontawesome-webfont.woff": "fontawesome-webfont.woff" },
+              { "src/bower_components/font-awesome/fonts/FontAwesome.otf": "FontAwesome.otf" }
+            ]
+          },
+          "nprogress": "src/bower_components/nprogress/nprogress.js"
+      },
+      "ignore": ["jquery"]
+    }
 }

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
 	"name": "Slimpost",
-	"version": "0.2.0",
+	"version": "0.3.0",
 	"dependencies": {
 		"normalize-css": "latest",
 		"font-awesome": "latest",
@@ -23,7 +23,7 @@
 	      		"mapping": [
 	      			{ "src/bower_components/normalize-css/normalize.css": "_normalize.scss" }
 	      		]
-	      	},   	
+	      	},
 	      	"font-awesome": {
 	      		"mapping": [
 	      			{ "src/bower_components/font-awesome/css/font-awesome.css": "_font-awesome.scss" },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Slimpost",
-	"version": "0.2.0",
+	"version": "0.3.0",
 	"description": "Minimal theme for Ghost",
 	"author": {
 		"name": "Infinitum Themes",

--- a/partials/header.hbs
+++ b/partials/header.hbs
@@ -1,4 +1,4 @@
-<header class="header" role="banner" {{#if @blog.cover}}style="background-image: url({{@blog.cover}});"{{/if}}>
+<header class="header" role="banner" {{#if @blog.cover_image}}style="background-image: url({{@blog.cover_image}});"{{/if}}>
 	<h1 class="blog-title">
 		<a href="{{@blog.url}}">{{@blog.title}}</a>
 	</h1>

--- a/partials/pagination.hbs
+++ b/partials/pagination.hbs
@@ -1,8 +1,8 @@
 <nav class="pagination" role="pagination">
     {{#if prev}}
-        <a class="newer-posts" href="{{pageUrl prev}}">&laquo; Newer</a>
+        <a class="newer-posts" href="{{page_url prev}}">&laquo; Newer</a>
     {{/if}}
     {{#if next}}
-        <a class="older-posts" href="{{pageUrl next}}">Older &raquo;</a>
+        <a class="older-posts" href="{{page_url next}}">Older &raquo;</a>
     {{/if}}
 </nav>

--- a/post.hbs
+++ b/post.hbs
@@ -8,17 +8,17 @@
 	<section class="post-full">
 		{{#post}}
 		<article itemscope itemtype="http://schema.org/BlogPosting" role="article" class="{{post_class}}">
-			<header class="post-header">        		
+			<header class="post-header">
     			<h2 itemprop="name headline" class="post-title">
     				<a href="{{url}}" itemprop="url">{{{title}}}</a>
     			</h2>
     			<div class="post-meta">
         			<time datetime="{{date format='YYYY-MM-DD'}}" itemprop="datePublished">{{date published_at format="MMMM DD, YYYY"}}</time>
         			{{#if tags}}
-    				<span class="delimiter">&#8226;</span> 
+    				<span class="delimiter">&#8226;</span>
 		        	{{#tags}}
 		            <span itemprop="keywords">{{name}}</span>{{#unless @last}}, {{/unless}}
-		          	{{/tags}}			        
+		          	{{/tags}}
 			      	{{/if}}
         		</div>
         		<hr>
@@ -28,8 +28,8 @@
     		</section>
     		<footer class="post-footer">
     			<div itemscope itemprop="author" itemtype="http://schema.org/Person" class="post-author">
-    				{{#if author.image}}
-	                	<img itemprop="image" src="{{author.image}}" alt="{{author.name}}" class="post-author-avatar">
+    				{{#if author.profile_image}}
+	                	<img itemprop="image" src="{{author.profile_image}}" alt="{{author.name}}" class="post-author-avatar">
 	              	{{/if}}
 					<div class="post-author-info">
 		              	<span itemprop="name">{{author.name}}</span>
@@ -41,8 +41,8 @@
     		</footer>
 		</article>
 		{{/post}}
-		
-		{{> comments}}	
+
+		{{> comments}}
 	</section>
 
 	{{> footer}}

--- a/post.hbs
+++ b/post.hbs
@@ -1,49 +1,49 @@
 {{!< default}}
 
 <main id="container" role="main">
-	{{> header}}
+  {{> header}}
 
-	{{> navigation}}
+  {{> navigation}}
 
-	<section class="post-full">
-		{{#post}}
-		<article itemscope itemtype="http://schema.org/BlogPosting" role="article" class="{{post_class}}">
-			<header class="post-header">
-    			<h2 itemprop="name headline" class="post-title">
-    				<a href="{{url}}" itemprop="url">{{{title}}}</a>
-    			</h2>
-    			<div class="post-meta">
-        			<time datetime="{{date format='YYYY-MM-DD'}}" itemprop="datePublished">{{date published_at format="MMMM DD, YYYY"}}</time>
-        			{{#if tags}}
-    				<span class="delimiter">&#8226;</span>
-		        	{{#tags}}
-		            <span itemprop="keywords">{{name}}</span>{{#unless @last}}, {{/unless}}
-		          	{{/tags}}
-			      	{{/if}}
-        		</div>
-        		<hr>
-    		</header>
-    		<section itemprop="articleBody" class="post-content">
-    			{{content}}
-    		</section>
-    		<footer class="post-footer">
-    			<div itemscope itemprop="author" itemtype="http://schema.org/Person" class="post-author">
-    				{{#if author.profile_image}}
-	                	<img itemprop="image" src="{{author.profile_image}}" alt="{{author.name}}" class="post-author-avatar">
-	              	{{/if}}
-					<div class="post-author-info">
-		              	<span itemprop="name">{{author.name}}</span>
-		              	{{#if author.bio}}
-		              	<p itemprop="description" class="post-author-bio">{{author.bio}}</p>
-		              	{{/if}}
-	              	</div>
-    			</div>
-    		</footer>
-		</article>
-		{{/post}}
+  <section class="post-full">
+    {{#post}}
+    <article itemscope itemtype="http://schema.org/BlogPosting" role="article" class="{{post_class}}">
+      <header class="post-header">
+          <h2 itemprop="name headline" class="post-title">
+            <a href="{{url}}" itemprop="url">{{{title}}}</a>
+          </h2>
+          <div class="post-meta">
+              <time datetime="{{date format='YYYY-MM-DD'}}" itemprop="datePublished">{{date published_at format="MMMM DD, YYYY"}}</time>
+              {{#if tags}}
+            <span class="delimiter">&#8226;</span>
+              {{#tags}}
+                <span itemprop="keywords">{{name}}</span>{{#unless @last}}, {{/unless}}
+                {{/tags}}
+              {{/if}}
+            </div>
+            <hr>
+        </header>
+        <section itemprop="articleBody" class="post-content">
+          {{content}}
+        </section>
+        <footer class="post-footer">
+          <div itemscope itemprop="author" itemtype="http://schema.org/Person" class="post-author">
+            {{#if author.profile_image}}
+                    <img itemprop="image" src="{{author.profile_image}}" alt="{{author.name}}" class="post-author-avatar">
+                  {{/if}}
+          <div class="post-author-info">
+                    <span itemprop="name">{{author.name}}</span>
+                    {{#if author.bio}}
+                    <p itemprop="description" class="post-author-bio">{{author.bio}}</p>
+                    {{/if}}
+                  </div>
+          </div>
+        </footer>
+    </article>
+    {{/post}}
 
-		{{> comments}}
-	</section>
+    {{> comments}}
+  </section>
 
-	{{> footer}}
+  {{> footer}}
 </main>


### PR DESCRIPTION
I recently tried to upload the theme to a Ghost install and got some very helpful error messages from Ghost about what needed to be updated.

Here's what I've done:
- made the required changes so the theme can now be uploaded to Ghost 1.21.7
- bumped the version to 0.3.0
- converted all indenting to spaces in a couple files that I touched

Please let me know if I should remove the indentation commits, or use a different version number.

I assume that this is also compatible with 1.22, but I don't have an easy way to test.